### PR TITLE
WorkspaceChangeListener: Reload config on changes to .eclipse-pmd

### DIFF
--- a/ch.acanda.eclipse.pmd.core/src/ch/acanda/eclipse/pmd/repository/ProjectModelRepository.java
+++ b/ch.acanda.eclipse.pmd.core/src/ch/acanda/eclipse/pmd/repository/ProjectModelRepository.java
@@ -37,7 +37,7 @@ import com.google.common.base.Strings;
  */
 public class ProjectModelRepository {
     
-    private static final String PMD_CONFIG_FILENAME = ".eclipse-pmd";
+    public static final String PMD_CONFIG_FILENAME = ".eclipse-pmd";
     
     public void save(final ProjectModel model) {
         checkNotNull(model, "The argument 'model' must not be null.");


### PR DESCRIPTION
Otherwise, changes to .eclipse-pmd done by hand (or via SCM) are never recognized.