### PR TITLE
PMDBuilder: Remove all project markers in clean action

### DIFF
--- a/ch.acanda.eclipse.pmd.core/src/ch/acanda/eclipse/pmd/builder/PMDBuilder.java
+++ b/ch.acanda.eclipse.pmd.core/src/ch/acanda/eclipse/pmd/builder/PMDBuilder.java
@@ -27,6 +27,7 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import ch.acanda.eclipse.pmd.PMDPlugin;
 import ch.acanda.eclipse.pmd.cache.RuleSetsCache;
 import ch.acanda.eclipse.pmd.cache.RuleSetsCacheLoader;
+import ch.acanda.eclipse.pmd.marker.MarkerUtil;
 import net.sourceforge.pmd.RuleSets;
 
 /**
@@ -39,6 +40,11 @@ public class PMDBuilder extends IncrementalProjectBuilder {
     public static final String ID = "ch.acanda.eclipse.pmd.builder.PMDBuilder";
 
     private static final RuleSetsCache CACHE = new RuleSetsCache(new RuleSetsCacheLoader(), PMDPlugin.getDefault().getWorkspaceModel());
+
+    @Override
+    protected void clean(final IProgressMonitor monitor) throws CoreException {
+        MarkerUtil.removeAllMarkers(getProject());
+    }
 
     @Override
     @SuppressWarnings("PMD.ReturnEmptyArrayRatherThanNull")


### PR DESCRIPTION
The PMD markers should be gone after cleaning the project.